### PR TITLE
implemented mixfix operator using Earley

### DIFF
--- a/Prop.hs
+++ b/Prop.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TupleSections, FlexibleContexts, GADTs, DeriveAnyClass, DeriveGeneric, OverloadedStrings #-}
 module Prop where
 import Unification
-import StringRep
+import qualified StringRep as SR
 import Miso.String(MisoString)
 import qualified Terms as T
 import GHC.Generics(Generic)
@@ -96,10 +96,10 @@ applySubst subst (Forall vs lcls g) = Forall vs (map (applySubst subst) lcls) (T
 -- A bit disappointing that this can't be cleanly lensified.
 getConclusionString :: Path -> Prop -> MisoString
 getConclusionString p prp = let (ctx, trm) = fromJust (ipreview (path p %. conclusion) prp)
-                             in toSexps ctx trm
+                             in SR.prettyPrint ctx trm
 
 setConclusionString :: Path -> MisoString -> Prop -> Either MisoString Prop
 setConclusionString p txt prp = iatraverseOf (path p %. conclusion) Right parse prp
   where
-    parse ctx _ = fromSexps ctx txt
+    parse ctx _ = SR.parse ctx txt
 

--- a/Rule.hs
+++ b/Rule.hs
@@ -167,7 +167,7 @@ instance Control Rule where
          pure $ over propUpdate id state' --hack..
   handle (InstantiateMetavariable i) state = do 
     new <- textInput 
-    case fromSexps [] new of 
+    case parse [] new of 
       Left e -> errorMessage $ "Parse error: " <> e 
       Right obj -> do
          pure $ over (proofState % proofTree) (PT.applySubst (T.fromUnifier [(i,obj)])) state

--- a/StringRep.hs
+++ b/StringRep.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE OverloadedStrings #-}
-module StringRep (toSexps, fromSexps) where
+{-# LANGUAGE OverloadedStrings, RecursiveDo, CPP #-}
+module StringRep (prettyPrint, parse) where
 
 import Data.Char
+import Control.Arrow(first)
 import Control.Monad(ap, when)
 import Data.List
 import Prelude hiding (lex)
@@ -13,23 +14,94 @@ import qualified Miso.String as MS
 import qualified Data.Text.Lazy.Builder as B
 import qualified Data.Text.Lazy as L
 import Terms
+import qualified Text.Earley as EP
+import qualified Text.Earley.Mixfix as EPM
+
+data Token = LParen | RParen | Word MS.MisoString | Dot | Binder MS.MisoString deriving (Show, Eq)
+
+holey :: String -> EPM.Holey MS.MisoString
+holey ""       = []
+holey ('_':xs) = Nothing : holey xs
+holey xs       = Just (MS.toMisoString i) : holey rest
+  where (i, rest) = span (/= '_') xs
+
+concatMixfix :: EPM.Holey Token -> MS.MisoString
+concatMixfix xs = MS.ms $ B.toLazyText $ go xs
+  where
+    go []            = B.fromText ""
+    go (Nothing:xs)  = B.fromText "_" <> go xs
+    go ((Just (Word x)):xs) = (B.fromText $ MS.fromMisoString x) <> go xs
+
+mixfixDef :: [[(String, EPM.Associativity)]]
+mixfixDef = [ [("_->_",          EPM.RightAssoc)]
+            , [("_,_",           EPM.NonAssoc)]
+            , [("if_then_else_", EPM.RightAssoc)]
+            , [("_|-_:_",        EPM.NonAssoc)]
+            , [("_+_",           EPM.LeftAssoc)]
+            , [("_*_",           EPM.LeftAssoc)]
+            ]
+
+mixfixTable :: [[(EPM.Holey MS.MisoString, EPM.Associativity)]]
+mixfixTable = (map . map) (first holey) mixfixDef
+
+grammar :: EP.Grammar r (EP.Prod r Token Token Term)
+grammar = mdo
+  ident     <- EP.rule $ getWord <$> EP.satisfy isLegalWord
+  atom      <- EP.rule $ Const <$> ident
+                      <|> EP.namedToken LParen *> program <* EP.namedToken RParen
+  normalApp <- EP.rule $ atom
+                      <|> Ap <$> normalApp <*> atom
+  mixfixApp <- EPM.mixfixExpression table normalApp mixfixCon
+  program   <- EP.rule $ mixfixApp 
+                      <|> Lam . maskCon <$> EP.satisfy isLegalBinder <*> program 
+  return program
+  where
+    maskCon (Binder b) = M b
+    mixfixCon op ts = applyApTelescope (Const $ concatMixfix op) ts
+    getWord (Word w) = w
+    table = map (map $ first $ map $ fmap (EP.namedToken . Word)) mixfixTable
+    illegalIdents = [s | xs <- mixfixTable , (ys, _) <- xs , Just s <- ys]
+    isLegalBinder (Binder b) = not $ elem b illegalIdents
+    isLegalBinder _ = False
+    isLegalWord (Word w) = not $ elem w illegalIdents 
+    isLegalWord _ = False
+
+postProc :: [Name] -> Term -> Term
+postProc ctx (Lam (M b) t) = Lam (M b) $ postProc (b:ctx) t
+postProc ctx (Ap t1 t2) = Ap (postProc ctx t1) (postProc ctx t2) 
+postProc ctx (Const x) | Just v <- elemIndex x ctx = LocalVar v
+                       | otherwise = Const x
 
 type Error = MS.MisoString
 
-toSexps :: [Name] -> Term -> MS.MisoString 
-toSexps ctx t = MS.ms $ B.toLazyText $ go ctx t
+printHoley :: MS.MisoString -> [B.Builder] -> B.Builder
+printHoley origin operends = go origin origin operends
+  where
+    go origin op [] = B.fromText $ MS.fromMisoString op
+    go origin op (x:xs) = case MS.uncons op of 
+      Just ('_', ops) | origin == op -> x <> " " <> go origin ops xs
+                      | ops == "" -> " " <> x <> go origin ops xs
+                      | otherwise -> " " <> x <> " " <> go origin ops xs
+      Just (o, ops) -> B.singleton o <> go origin ops (x:xs)
+
+prettyPrint :: [Name] -> Term -> MS.MisoString 
+prettyPrint ctx t = MS.ms $ B.toLazyText $ go ctx t
 go :: [Name] -> Term -> B.Builder 
 go ctx (Lam (M x) t) = B.fromText (MS.fromMisoString x) <> ". " <> go (x:ctx) t
 go ctx e = go' ctx e
-go' ctx (Ap a1 a2) = go' ctx a1 <> " " <> go'' ctx a2
+go' ctx (Ap a1 a2) 
+  | (x, ts) <- peelApTelescope (Ap a1 a2) = case x of 
+    Const op 
+      | isMixfix op, MS.count "_" op == length ts -> printHoley op $ (map $ go'' ctx) ts
+      | otherwise -> go' ctx a1 <> " " <> go'' ctx a2
+        where
+          isMixfix op = elem op [MS.toMisoString ys | xs <- mixfixDef, (ys, _) <- xs]  
 go' ctx (Lam n t) = "(" <> go ctx (Lam n t) <> ")"
 go' ctx e = go'' ctx e
 go'' ctx (LocalVar v) = B.fromText (MS.fromMisoString (ctx !! v))
 go'' ctx (Const id) = B.fromText $ MS.fromMisoString $ id
 go'' ctx (MetaVar id) = "?" <> B.fromText (MS.fromMisoString $ MS.pack (show id))
 go'' ctx e = "(" <> go ctx e <> ")"
-
-data Token = LParen | RParen | Word MS.MisoString | Dot | Binder MS.MisoString deriving (Show, Eq)
 
 lexer :: MS.MisoString -> [Token]
 lexer str | (x,y) <- MS.span isSpace str
@@ -108,3 +180,16 @@ fromSexps ctx s = case runParser (parser ctx) . preprocess . lexer $ s of
               (Left e,_) -> Left e
               (Right v,[]) -> Right v
               (_,s) -> Left $ "Parse error: Leftover '" <> MS.concat (map unlex s) <> "'"
+
+fromMixfix :: [Name] -> MS.MisoString -> Either Error Term
+fromMixfix ctx s = case EP.fullParses (EP.parser grammar) $ preprocess . lexer $ s of
+                   ([], rep) -> Left $ "Parse error: unexpected character at position " <> MS.toMisoString (EP.position rep)
+                   ([x], rep) -> Right $ postProc ctx x
+                   ((x:xs), rep) -> Left $ "Parse error: ambiguous parsing result: " <> MS.concat (map ((prettyPrint ctx). (postProc ctx)) (x:xs))
+
+parse :: [Name] -> MS.MisoString -> Either Error Term
+#ifdef MIXFIX
+parse = fromMixfix
+#else
+parse = fromSexps
+#endif

--- a/View/Paragraph.hs
+++ b/View/Paragraph.hs
@@ -2,7 +2,7 @@
 module View.Paragraph where
 import Miso 
 import DisplayOptions
-import StringRep
+import StringRep as SR
 import qualified Item as I
 import qualified Miso.String as MS
 import qualified Paragraph as P
@@ -25,7 +25,7 @@ renderText txt = normalText txt
       let (ctx, txt') = case MS.span (/= ':') txt of
             (_, crest) | MS.null crest -> ([], txt)
             (ctx, crest) | Just (_, rest) <- MS.uncons crest -> (MS.words ctx, rest)
-       in case fromSexps ctx txt' of
+       in case SR.parse ctx txt' of
             Left _ -> ["$", text txt, "$"]
             Right t -> [inline "inline-math" [renderTermCtx ctx (TDO True True) t]]
 

--- a/app.cabal
+++ b/app.cabal
@@ -7,7 +7,13 @@ license-file:        LICENSE
 build-type:          Simple
 cabal-version:       >=1.10
 
+flag mixfix
+  description: Enable mixfix operator
+  default:     False
+
 executable app
+  if flag(mixfix)
+    cpp-options: -DMIXFIX
   main-is:             Main.hs
   other-modules: 
     StringRep 
@@ -34,5 +40,5 @@ executable app
     View.Item
   ghcjs-options:
     -dedupe
-  build-depends:       base, ghcjs-base, aeson, text, miso, mtl, containers, optics-core
+  build-depends:       base, ghcjs-base, aeson, text, miso, mtl, containers, optics-core, Earley
   default-language:    Haskell2010 


### PR DESCRIPTION
The new Earley parser can be enabled by passing `cabal configure -f mixfix` flag.